### PR TITLE
Updating to wse3

### DIFF
--- a/synchronous-slide-right/layout.csl
+++ b/synchronous-slide-right/layout.csl
@@ -1,17 +1,14 @@
 param kernel_width: u16;
 param num_elems: u16;
 
-const LAUNCH: color = @get_color(8);
-
 // Instantiate memcpy infrastructure
 const memcpy = @import_module("<memcpy/get_params>", .{
   .width = kernel_width,
-  .height = 1,
-  .LAUNCH = LAUNCH
+  .height = 1
   });
 
-const fab_east_color = @get_color(14);
-const fab_west_color = @get_color(15);
+const fab_east_color = @get_color(2);
+const fab_west_color = @get_color(3);
 
 layout {
   // Use a single row of kernel_width PEs (columns=kernel_width, rows=1)
@@ -27,8 +24,8 @@ layout {
       .fab_west_color = fab_west_color
     });
 
-    const default_route = .{ .rx = .{ RAMP }, .tx = .{ EAST }, .pop_mode = .{ .always_pop = true } };
-    const switch_pos = .{ .pos1 = .{ .rx = WEST }, .pos2 = .{ .tx = RAMP } };
+    const default_route = .{ .rx = .{ RAMP }, .tx = .{ EAST } };
+    const switch_pos = .{ .pos1 = .{ .rx = WEST }, .pos2 = .{ .tx = RAMP }, .pop_mode = .{ .always_pop = true } };
     const switch_0 = @concat_structs(switch_pos, .{ .current_switch_pos = 0 }); // RAMP --> EAST
     const switch_1 = @concat_structs(switch_pos, .{ .current_switch_pos = 1 }); // WEST --> EAST
     const switch_2 = @concat_structs(switch_pos, .{ .current_switch_pos = 2 }); // RAMP --> WEST

--- a/synchronous-slide-right/pe_program.csl
+++ b/synchronous-slide-right/pe_program.csl
@@ -14,6 +14,9 @@ const EXIT:      local_task_id = @get_local_task_id(9);
 const send_ctrl: local_task_id = @get_local_task_id(10);
 const recv:      local_task_id = @get_local_task_id(11);
 
+const iq:        input_queue = @get_input_queue(2);
+const oq:        output_queue = @get_output_queue(1);
+
 // This module is needed for memcpy infrastructure
 const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
 
@@ -36,8 +39,8 @@ var arr1 = @zeros([num_elems]f32);
 const arr1_dsd = @get_dsd(mem1d_dsd, .{ .tensor_access = |i|{num_elems} -> arr1[i] });
 var ptr_arr1 : [*]f32 = &arr1;
 
-const send_east_dsd = @get_dsd(fabout_dsd, .{.fabric_color = fab_east_color, .extent = num_elems, .output_queue = @get_output_queue(1) });
-const recv_west_dsd = @get_dsd(fabin_dsd,  .{.fabric_color = fab_east_color, .extent = num_elems, .input_queue = @get_input_queue(2) });
+const send_east_dsd = @get_dsd(fabout_dsd, .{.fabric_color = fab_east_color, .extent = num_elems, .output_queue = oq });
+const recv_west_dsd = @get_dsd(fabin_dsd,  .{.fabric_color = fab_east_color, .extent = num_elems, .input_queue = iq });
 
 fn main_fn() void {
   timestamp.enable_tsc();
@@ -62,7 +65,7 @@ task send_ctrl_wlt() void {
       .extent = 1,
       .control = true,
       .fabric_color = fab_east_color,
-      .output_queue = @get_output_queue(1),
+      .output_queue = oq,
       });
 
   var ctrl_dsd = @get_dsd(mem1d_dsd, .{ .tensor_access = |i|{1} -> ctrl[i] });
@@ -112,5 +115,9 @@ comptime {
   @export_symbol(ptr_arr1, "arr1");
   @export_symbol(ptr_timer_buf, "maxmin_time");
   @export_symbol(main_fn);
-  @rpc(@get_data_task_id(sys_mod.LAUNCH));
+
+  if (@is_arch("wse3")) {
+    @initialize_queue(iq, .{ .color = fab_east_color });
+    @initialize_queue(oq, .{ .color = fab_east_color });
+  }
 }

--- a/synchronous-slide-right/sweep.py
+++ b/synchronous-slide-right/sweep.py
@@ -40,7 +40,7 @@ def cslc_compile(
   args.append("--fabric-offsets=4,1")
   args.append(f"--params=kernel_width:{kernel_width},num_elems:{num_elems}")
   args.append(f"-o={name}")
-  args.append("--arch=wse2")
+  args.append("--arch=wse3")
   args.append("--memcpy")
   args.append("--channels=1")
   print(f"subprocess.check_call(args = {args}")

--- a/synchronous-slide/layout.csl
+++ b/synchronous-slide/layout.csl
@@ -1,17 +1,14 @@
 param kernel_width: u16;
 param num_elems: u16;
 
-const LAUNCH: color = @get_color(8);
-
 // Instantiate memcpy infrastructure
 const memcpy = @import_module("<memcpy/get_params>", .{
   .width = kernel_width,
-  .height = 1,
-  .LAUNCH = LAUNCH
+  .height = 1
   });
 
-const fab_east_color = @get_color(14);
-const fab_west_color = @get_color(15);
+const fab_east_color = @get_color(2);
+const fab_west_color = @get_color(3);
 
 layout {
   // Use a single row of kernel_width PEs (columns=kernel_width, rows=1)
@@ -27,8 +24,8 @@ layout {
       .fab_west_color = fab_west_color
     });
 
-    const east_default_route = .{ .rx = .{ RAMP }, .tx = .{ EAST }, .pop_mode = .{ .always_pop = true } };
-    const east_switch_pos = .{ .pos1 = .{ .rx = WEST }, .pos2 = .{ .tx = RAMP } };
+    const east_default_route = .{ .rx = .{ RAMP }, .tx = .{ EAST } };
+    const east_switch_pos = .{ .pos1 = .{ .rx = WEST }, .pos2 = .{ .tx = RAMP }, .pop_mode = .{ .always_pop = true } };
     const east_switch_0 = @concat_structs(east_switch_pos, .{ .current_switch_pos = 0 }); // RAMP --> EAST
     const east_switch_1 = @concat_structs(east_switch_pos, .{ .current_switch_pos = 1 }); // WEST --> EAST
     const east_switch_2 = @concat_structs(east_switch_pos, .{ .current_switch_pos = 2 }); // WEST --> RAMP
@@ -53,8 +50,8 @@ layout {
       @set_color_config(x, 0, fab_east_color, .{ .routes = east_default_route, .switches = east_switch_0 });
     }
    
-    const west_default_route = .{ .rx = .{ RAMP }, .tx = .{ WEST }, .pop_mode = .{ .always_pop = true } };
-    const west_switch_pos = .{ .pos1 = .{ .rx = EAST }, .pos2 = .{ .tx = RAMP } };
+    const west_default_route = .{ .rx = .{ RAMP }, .tx = .{ WEST } };
+    const west_switch_pos = .{ .pos1 = .{ .rx = EAST }, .pos2 = .{ .tx = RAMP }, .pop_mode = .{ .always_pop = true } };
     const west_switch_0 = @concat_structs(west_switch_pos, .{ .current_switch_pos = 0 }); // RAMP --> WEST
     const west_switch_1 = @concat_structs(west_switch_pos, .{ .current_switch_pos = 1 }); // EAST --> WEST
     const west_switch_2 = @concat_structs(west_switch_pos, .{ .current_switch_pos = 2 }); // EAST --> RAMP

--- a/synchronous-slide/pe_program.csl
+++ b/synchronous-slide/pe_program.csl
@@ -42,11 +42,16 @@ var arr2 = @zeros([num_elems]f32);
 const arr2_dsd = @get_dsd(mem1d_dsd, .{ .tensor_access = |i|{num_elems} -> arr2[i] });
 var ptr_arr2 : [*]f32 = &arr2;
 
-const send_east_dsd = @get_dsd(fabout_dsd, .{.fabric_color = fab_east_color, .extent = num_elems, .output_queue = @get_output_queue(2) });
-const recv_west_dsd = @get_dsd(fabin_dsd,  .{.fabric_color = fab_east_color, .extent = num_elems, .input_queue = @get_input_queue(3) });
+const send_east_q : output_queue= @get_output_queue(2);
+const recv_west_q : input_queue= @get_input_queue(3);
+const send_west_q : output_queue= @get_output_queue(4);
+const recv_east_q : input_queue= @get_input_queue(5);
 
-const send_west_dsd = @get_dsd(fabout_dsd, .{.fabric_color = fab_west_color, .extent = num_elems, .output_queue = @get_output_queue(4) });
-const recv_east_dsd = @get_dsd(fabin_dsd,  .{.fabric_color = fab_west_color, .extent = num_elems, .input_queue = @get_input_queue(5) });
+const send_east_dsd = @get_dsd(fabout_dsd, .{.fabric_color = fab_east_color, .extent = num_elems, .output_queue = send_east_q });
+const recv_west_dsd = @get_dsd(fabin_dsd,  .{.fabric_color = fab_east_color, .extent = num_elems, .input_queue = recv_west_q });
+
+const send_west_dsd = @get_dsd(fabout_dsd, .{.fabric_color = fab_west_color, .extent = num_elems, .output_queue = send_west_q });
+const recv_east_dsd = @get_dsd(fabin_dsd,  .{.fabric_color = fab_west_color, .extent = num_elems, .input_queue = recv_east_q });
 
 fn main_fn() void {
   timestamp.enable_tsc();
@@ -81,7 +86,7 @@ task send_east_ctrl_wlt() void {
       .extent = 1,
       .control = true,
       .fabric_color = fab_east_color,
-      .output_queue = @get_output_queue(2),
+      .output_queue = send_east_q,
       });
 
   @mov32(fabOutCtrlDsd, ctrl_dsd, .{ .async = true, .activate = recv_west});
@@ -92,7 +97,7 @@ task send_west_ctrl_wlt() void {
       .extent = 1,
       .control = true,
       .fabric_color = fab_west_color,
-      .output_queue = @get_output_queue(4),
+      .output_queue = send_west_q,
       });
 
   @mov32(fabOutCtrlDsd, ctrl_dsd, .{ .async = true, .activate = recv_east});
@@ -154,5 +159,11 @@ comptime {
   @export_symbol(ptr_arr2, "arr2");
   @export_symbol(ptr_timer_buf, "maxmin_time");
   @export_symbol(main_fn);
-  @rpc(@get_data_task_id(sys_mod.LAUNCH));
+
+  if (@is_arch("wse3")) {
+    @initialize_queue(send_east_q, .{ .color = fab_east_color });
+    @initialize_queue(recv_west_q, .{ .color = fab_east_color });
+    @initialize_queue(send_west_q, .{ .color = fab_west_color });
+    @initialize_queue(recv_east_q, .{ .color = fab_west_color });
+  }
 }

--- a/synchronous-slide/sweep.py
+++ b/synchronous-slide/sweep.py
@@ -40,7 +40,7 @@ def cslc_compile(
   args.append("--fabric-offsets=4,1")
   args.append(f"--params=kernel_width:{kernel_width},num_elems:{num_elems}")
   args.append(f"-o={name}")
-  args.append("--arch=wse2")
+  args.append("--arch=wse3")
   args.append("--memcpy")
   args.append("--channels=1")
   print(f"subprocess.check_call(args = {args}")


### PR DESCRIPTION
Update code base to support the wse3 architecture and SDK 1.3. Modify `--arch` flag in `sweep.py` to build for wse2 as before.

Cycle counts for `kernel_width=8` and `num_elems = 10`:
| | slide-right wse2 | slide-right wse3 | slide wse2 | slide wse3 |
|--------|--------|--------|--------|--------|
| Left | 153 | 139 | 82 | 113 |
| Middle | 108 | 96 | 88 | 84 |
| Right | 13 | 16 | 134 | 109 |

Note, the colours had to be changed for wse3 to avoid this error:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  the received length (0 bytes) is not expected (320 bytes), could be a kernel stall 
```